### PR TITLE
Fix for one-at-a-time print collision

### DIFF
--- a/definitions/elegoo_neptune_2.def.json
+++ b/definitions/elegoo_neptune_2.def.json
@@ -126,6 +126,8 @@
         "machine_depth": {"default_value": 235},
         "machine_heated_bed": {"default_value": true},
         "material_diameter": { "default_value": 1.75 },
+		"machine_head_with_fans_polygon": {"value": [[-30, 35], [-30, -10], [25, 35], [25, -10]]},
+		"gantry_height": {"value": 30},
         "speed_print": { "value": 60.0 } ,
         "z_seam_type":{"default_value": "back"},
         "z_seam_corner":{"default_value": "z_seam_corner_weighted"},


### PR DESCRIPTION
# Software/Hardware
- Cura 4.13.1
- Neptune 2S

# Inspiration
Recently I had a print/printhead collision when using the one-at-a-time print mode. I've identified the cause as an (un)configured machine head bounding box.

# Fixes entailed
- I added the bounding box for the machine head in config
- I also added the gantry height so the print doesn't get knocked off by the gantry (as opposed to the printhead)

# Image:
![image](https://user-images.githubusercontent.com/26728734/156319334-a47d9ec6-e900-4f86-b2e1-7c0165a10ead.png)

# Additional Notes
- Only changed for the base Neptune 2 profile
  - If anyone can confirm and change the dimensions for Neptune 2D that'll be great!